### PR TITLE
Change the param order for get, to make it similar to Net::HTTP.get

### DIFF
--- a/lib/tor/http.rb
+++ b/lib/tor/http.rb
@@ -5,7 +5,7 @@ module Tor
 
   class HTTP
 
-    def self.get(host, port = 80, path = "/")
+    def self.get(host, path = "/", port = 80)
       res = ""
       Net::HTTP.SOCKSProxy(Tor.configuration.ip, Tor.configuration.port).start(host, port) do |http|
         res = http.get(path)

--- a/lib/tor/http.rb
+++ b/lib/tor/http.rb
@@ -5,10 +5,17 @@ module Tor
 
   class HTTP
 
-    def self.get(host, path = "/", port = 80)
+    def self.get(uri_or_host, path = nil, port = nil)
       res = ""
+      host = nil
+      if path
+        host = uri_or_host
+      else
+        host = uri_or_host.hostname
+        port = uri_or_host.port
+      end
       Net::HTTP.SOCKSProxy(Tor.configuration.ip, Tor.configuration.port).start(host, port) do |http|
-        res = http.get(path)
+        res = http.get(path || uri_or_host.path)
       end
       res
     end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -10,7 +10,7 @@ describe "Http" do
     end
 
     it "makes a HTTP request to Google" do
-      res = Tor::HTTP.get("google.com", 80, "/")
+      res = Tor::HTTP.get("google.com", "/", 80)
       res.code.should eq("301")
     end
     

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -4,14 +4,26 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe "Http" do
   
   describe "get" do
-    it "default params" do
-      res = Tor::HTTP.get("google.com")
-      res.code.should eq("301")
+    
+    context "with invalid parameters" do
+      it "does not work" do
+        expect { Tor::HTTP.get("google.com") }.to raise_error
+      end
     end
-
-    it "makes a HTTP request to Google" do
-      res = Tor::HTTP.get("google.com", "/", 80)
-      res.code.should eq("301")
+    
+    context "with URI parameter" do
+      it "works" do
+        res = Tor::HTTP.get(URI('http://google.com/'))
+        res.code.should eq("301")
+      end
+    end
+    
+    context "with host, path and port parameters" do
+      it "works" do
+        res = Tor::HTTP.get("google.com", "/", 80)
+        res.code.should eq("301")
+      end
+      
     end
     
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -15,7 +15,7 @@ describe "Configure" do
       proxy = Net::HTTP.SOCKSProxy("127.0.0.1", 9050)
       proxy.stub(:start)
       Net::HTTP.should_receive(:SOCKSProxy).with("a", 9051).and_return( proxy)
-      Tor::HTTP.get("google.com")
+      Tor::HTTP.get(URI('http://google.com/'))
     end
   end
 


### PR DESCRIPTION
Hey,

I changed the param order to make it similar to Net::HTTP.get.
This is a breaking change, but since we are not on 1.0.0 yet theres no need to increase the Major version.
