### PR TITLE
Support for arbitrary HTTP headers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,6 +28,14 @@ The default port configuration is 9050 and ip configuration is 127.0.0.1. If you
      config.port = 9050
   end  
 
+You can also set additional custom header fields, e.g. User-Agent:
+
+Tor.configure do |config|
+   config.add_header('User-Agent', 'Netscape 2.0')
+end  
+
+
+
 == Contributing to tor_requests
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.

--- a/README.rdoc
+++ b/README.rdoc
@@ -30,9 +30,9 @@ The default port configuration is 9050 and ip configuration is 127.0.0.1. If you
 
 You can also set additional custom header fields, e.g. User-Agent:
 
-Tor.configure do |config|
-   config.add_header('User-Agent', 'Netscape 2.0')
-end  
+  Tor.configure do |config|
+    config.add_header('User-Agent', 'Netscape 2.0')
+  end  
 
 
 

--- a/lib/tor/configuration.rb
+++ b/lib/tor/configuration.rb
@@ -8,9 +8,15 @@ module Tor
     attr_accessor :ip,
                   :port
     
+    
+    def add_header(header, value)
+      @headers[header] = value
+    end
+    
     def initialize
       @ip = '127.0.0.1'
       @port = 9050
+      @headers = Hash.new
     end    
     
   end

--- a/lib/tor/configuration.rb
+++ b/lib/tor/configuration.rb
@@ -8,6 +8,7 @@ module Tor
     attr_accessor :ip,
                   :port
     
+    attr_reader :headers
     
     def add_header(header, value)
       @headers[header] = value

--- a/lib/tor/configuration.rb
+++ b/lib/tor/configuration.rb
@@ -8,9 +8,16 @@ module Tor
     attr_accessor :ip,
                   :port
     
+    attr_reader :headers
+    
+    def add_header(header, value)
+      @headers[header] = value
+    end
+    
     def initialize
       @ip = '127.0.0.1'
       @port = 9050
+      @headers = Hash.new
     end    
     
   end

--- a/lib/tor/http.rb
+++ b/lib/tor/http.rb
@@ -17,6 +17,7 @@ module Tor
       Net::HTTP.SOCKSProxy(Tor.configuration.ip, Tor.configuration.port).start(host, port) do |http|
         request = Net::HTTP::Get.new(path || uri_or_host.path)
         Tor.configuration.headers.each do |header, value|
+          request.delete(header)
           request.add_field(header, value)
         end
         
@@ -40,6 +41,7 @@ module Tor
         request = Net::HTTP::Post.new(path)
         request.set_form_data(post_options)
         Tor.configuration.headers.each do |header, value|
+          request.delete(header)
           request.add_field(header, value)
         end
         res = http.request(request)

--- a/lib/tor/http.rb
+++ b/lib/tor/http.rb
@@ -15,7 +15,12 @@ module Tor
         port = uri_or_host.port
       end
       Net::HTTP.SOCKSProxy(Tor.configuration.ip, Tor.configuration.port).start(host, port) do |http|
-        res = http.get(path || uri_or_host.path)
+        request = Net::HTTP::Get.new(path || uri_or_host.path)
+        Tor.configuration.headers.each do |header, value|
+          request.add_field(header, value)
+        end
+        
+        res = http.request(request);
       end
       res
     end
@@ -34,6 +39,9 @@ module Tor
       Net::HTTP.SOCKSProxy(Tor.configuration.ip, Tor.configuration.port).start(host, port) do |http|
         request = Net::HTTP::Post.new(path)
         request.set_form_data(post_options)
+        Tor.configuration.headers.each do |header, value|
+          request.add_field(header, value)
+        end
         res = http.request(request)
       end
       res

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,11 +7,24 @@ describe "Configure" do
     Tor::Configuration.new.port.should eq(9050)
   end
 
+  it "default headers" do
+    Tor::Configuration.new.headers.should eq(Hash.new)  
+  end
+  
+
   it "default ip" do
     Tor::Configuration.new.ip.should eq('127.0.0.1')
   end
 
   context "initialize" do
+
+    it "default headers" do
+      config = Tor::Configuration.new
+      config.add_header('User-Agent', 'Netscape 2.0')
+      config.headers.should eq({'User-Agent' => 'Netscape 2.0'})
+    end
+    
+
     it "default port" do
       config = Tor::Configuration.new
       config.port = 99

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -10,6 +10,7 @@ describe "Configure" do
       Tor.configure do |config|
         config.ip = "a"
         config.port = 9051
+        config.add_header('User-Agent', 'Netscape 2.0')
       end
 
       proxy = Net::HTTP.SOCKSProxy("127.0.0.1", 9050)


### PR DESCRIPTION
This patch allows the user to specify arbitary HTTP headers, for example:

```
Tor.configure do |config|
  config.add_header('User-Agent', 'Netscape 2.0')
 end
```

This patch includes RSPEC coverage for the change as well as documentation...

Thanks!
Stephen
