### PR TITLE
Customizable redirect limit

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,7 +24,8 @@ with URIs (http & https)
 
 with redirects
   res = Tor::HTTP.get("google.com", "/", 80, 10)
-  By default 3 redirects are followed. To prevent infinite loops a TooManyRedirects error is raised.
+  By default 3 redirects are followed. 
+  To prevent infinite loops a TooManyRedirects error is raised.
   The limit can be changed by updating the last parameter.
 
 The default port configuration is 9050 and ip configuration is 127.0.0.1. If you need to change configuration, you can use:

--- a/README.rdoc
+++ b/README.rdoc
@@ -22,24 +22,28 @@ with URIs (http & https)
   Tor::HTTP.get(URI('https://github.com/'))
   Tor::HTTP.post(URI('http://posttestserver.com/post.php?dir=example'), {"var" => "variable"})
 
-  
+with redirects
+  res = Tor::HTTP.get("google.com", "/", 80, 10)
+  By default 3 redirects are followed. To prevent infinite loops a TooManyRedirects error is raised.
+  The limit can be changed by updating the last parameter.
+
 The default port configuration is 9050 and ip configuration is 127.0.0.1. If you need to change configuration, you can use:
 
   Tor.configure do |config|
      config.ip = "127.0.0.1"
      config.port = 9050
-  end  
+  end
 
 You can also set additional custom header fields, e.g. User-Agent:
 
   Tor.configure do |config|
     config.add_header('User-Agent', 'Netscape 2.0')
-  end  
+  end
 
 
 
 == Contributing to tor_requests
- 
+
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.
 * Fork the project.

--- a/lib/tor/http.rb
+++ b/lib/tor/http.rb
@@ -7,12 +7,12 @@ module Tor
     class TooManyRedirects < StandardError; end
 
     class << self
-      attr_accessor :redirects_count
+      attr_accessor :redirects_made
     end
 
     def self.get(uri_or_host, path = nil, port = nil, max_redirects = 3)
       res, host = "", nil
-      self.redirects_count = 0
+      self.redirects_made = 0
 
       if path
         host = uri_or_host
@@ -32,6 +32,7 @@ module Tor
         res = http.request(request)
         res = follow_redirect(res, http, max_redirects) # Follow redirects
       end
+
       res
     end
 
@@ -77,12 +78,11 @@ module Tor
 
     def self.follow_redirect(response, http, max_redirects)
       if response.kind_of?(Net::HTTPRedirection)
-        raise TooManyRedirects if self.redirects_count >= max_redirects
+        raise TooManyRedirects if self.redirects_made >= max_redirects
         request  = Net::HTTP::Get.new(fetch_redirect_url(response))
         response = http.request(request)
-        self.redirects_count += 1
+        self.redirects_made += 1
         response = follow_redirect(response, http, max_redirects)
-
       else
         response
       end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -17,10 +17,12 @@ describe "Http" do
           res.code.should eq("200")
         end
 
-        it "raises TooManyRedirects error" do
-          stub_const("Tor::HTTP::REDIRECT_LIMIT", 1)
-          expect { Tor::HTTP.get(URI("#{protocol}://google.com/")) }.to raise_error("Tor::HTTP::TooManyRedirects")
+        context "with custom redirects limit" do
+          it "raises TooManyRedirects error after 1 retry" do
+            expect { Tor::HTTP.get(URI("#{protocol}://bit.ly/1ngrqeH"), nil, nil, 1) }.to raise_error("Tor::HTTP::TooManyRedirects")
+          end
         end
+
       end
     end
 


### PR DESCRIPTION
- allow the redirect limit to be customizable. It defaults to 3. A TooManyRedirects is raised to prevent infinite loops
-  updated ReadMe
